### PR TITLE
AWP-2139: The upload banner doesn't disappear after the user closes it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "A Component Library",
   "scripts": {
     "format": "prettier --write --parser typescript '**/*.{ts,tsx}'",

--- a/src/components/alertMessage/AlertMessage.tsx
+++ b/src/components/alertMessage/AlertMessage.tsx
@@ -18,6 +18,7 @@ export interface AlertMessageProps {
   alertType?: "positive" | "negative" | "warning";
   display?: boolean;
   onLinkClick?: () => void;
+  onClose?: () => void;
 }
 
 export const AlertMessage: React.FC<AlertMessageProps> = ({
@@ -26,10 +27,12 @@ export const AlertMessage: React.FC<AlertMessageProps> = ({
   alertType = "positive",
   display = true,
   onLinkClick = () => {},
+  onClose = () => {},
 }) => {
   const [displayAlert, setDisplayAlert] = useState(display);
   const handleCancelAlert = () => {
     setDisplayAlert(false);
+    onClose();
   };
 
   return (


### PR DESCRIPTION
- update the props of AlertMessage